### PR TITLE
Corrige imagens achatadas: faltava height: auto no reset

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -30,10 +30,16 @@ body {
 }
 
 /* O "height: auto" nao e opcional aqui: sem ele, quando o max-width reduz a
-   largura, o atributo height do HTML continua valendo e a imagem achata. Vale
-   para qualquer imagem com width/height no markup dentro de um container mais
-   estreito que ela. Quem precisa de altura fixa (as miniaturas da galeria)
-   sobrescreve com uma regra mais especifica. */
+   largura, o atributo height do markup continua valendo e o elemento e
+   desenhado achatado. Vale para qualquer <img> ou <video> com width/height no
+   markup dentro de um container mais estreito que ele.
+
+   A consequencia e diferente nos dois casos: a imagem realmente deforma,
+   enquanto o video, cujo object-fit padrao e "contain", encaixa o quadro com
+   barras dentro da caixa errada. Feio nos dois, destrutivo so no primeiro.
+
+   Quem precisa de altura fixa (as miniaturas da galeria) sobrescreve com uma
+   regra mais especifica. */
 img,
 video {
   max-width: 100%;

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -29,9 +29,15 @@ body {
   background: #fff;
 }
 
+/* O "height: auto" nao e opcional aqui: sem ele, quando o max-width reduz a
+   largura, o atributo height do HTML continua valendo e a imagem achata. Vale
+   para qualquer imagem com width/height no markup dentro de um container mais
+   estreito que ela. Quem precisa de altura fixa (as miniaturas da galeria)
+   sobrescreve com uma regra mais especifica. */
 img,
 video {
   max-width: 100%;
+  height: auto;
   border: 0;
   vertical-align: middle;
 }


### PR DESCRIPTION
Corrige regressão introduzida por mim em #75.

O `max-width: 100%` que entrou no reset veio **sem o `height: auto` que o acompanha**. Quando o `max-width` reduz a largura, o atributo `height` do HTML continua valendo — e a imagem é desenhada achatada.

## Impacto

Atingia toda imagem com `width`/`height` no markup dentro de um container mais estreito que ela:

| página | imagem | exibida | correto | desvio |
|---|---|---|---|---|
| sobre, 1280px | fundadores | 750×683 | 750×500 | **27 %** |
| sobre, 375px | fundadores | 345×683 | 345×230 | **66 %** |
| atividades, 375px | as 14 de cursos | 343×198 | 343×260 | **31 %** |

As miniaturas da galeria não eram afetadas: têm altura fixa por regra mais específica e usam `object-fit`, que recorta de propósito em vez de distorcer.

## Por que passou pela verificação da fase 3

Vale registrar, porque é instrutivo. Eu tinha medido:

- **a largura das imagens** — e ela estava certa (o `max-width` fazia o seu trabalho);
- **a altura dos containers** — e ela batia com a do site antigo.

O segundo ponto é a armadilha: a altura batia *justamente porque estava errada do mesmo jeito*. No site antigo a imagem tinha 683 px de altura (tamanho natural, transbordando a coluna); no novo, 683 px de altura (achatada, dentro da coluna). Container idêntico, imagem destruída.

Nenhuma das duas medições olhava para a **proporção**, que é o que estava quebrado.

## Correção e nova checagem

Uma linha no reset, mais um comentário explicando por que ela não é opcional.

Adicionei uma verificação que compara a proporção exibida com a natural de cada imagem, em todas as páginas e nas duas larguras, ignorando as que usam `object-fit` diferente de `fill` (essas recortam de propósito):

```
antes:   9 imagens distorcidas
depois:  0 imagens distorcidas
```

Conferido também a olho, nas duas imagens afetadas.

**Regressão**: 22/22 na bateria funcional, html-proofer limpo com checagem externa.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXzfu6VerNdFUpdzm91FsZ)_